### PR TITLE
task/user delete

### DIFF
--- a/chat-api/src/main/java/com/nameless/social/api/controller/UserController.java
+++ b/chat-api/src/main/java/com/nameless/social/api/controller/UserController.java
@@ -152,4 +152,11 @@ public class UserController {
 	) {
 		return CommonResponse.success(HttpStatus.OK);
 	}
+
+	@Operation(summary = "사용자 서비스 탈퇴")
+	@DeleteMapping("/user")
+	public CommonResponse<Object> deleteUser(@RequestParam("email") final String email) {
+		userService.deleteUser(email);
+		return CommonResponse.success(HttpStatus.OK);
+	}
 }

--- a/chat-api/src/main/java/com/nameless/social/api/exception/ErrorCode.java
+++ b/chat-api/src/main/java/com/nameless/social/api/exception/ErrorCode.java
@@ -23,6 +23,12 @@ public enum ErrorCode {
 
 	// Club
 	CLUB_NOT_FOUND(HttpStatus.NOT_FOUND, "CR001", "Club not found"),
+
+	// UserGroup
+	USER_GROUP_NOT_FOUND(HttpStatus.NOT_FOUND, "UG001", "User is not a member of any group"),
+
+	// UserClub
+	USER_CLUB_NOT_FOUND(HttpStatus.NOT_FOUND, "UC001", "User is not a member of any club"),
 	;
 
 	private final HttpStatus status;

--- a/chat-api/src/main/java/com/nameless/social/api/exception/GlobalExceptionHandler.java
+++ b/chat-api/src/main/java/com/nameless/social/api/exception/GlobalExceptionHandler.java
@@ -12,14 +12,15 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class GlobalExceptionHandler {
 	@ExceptionHandler(CustomException.class)
 	protected ResponseEntity<CommonResponse<ErrorResponse>> handleCustomException(CustomException e) {
-		log.warn(">>> Custom Exception: {}", e.getMessage());
+		log.warn("Custom Exception >>> {}", e.getErrorCode());
+		log.warn("Custom Exception >>> {}", e.getMessage());
 		final ErrorResponse errorResponse = ErrorResponse.of(e.getErrorCode());
 		return new ResponseEntity<>(CommonResponse.error(errorResponse), e.getErrorCode().getStatus());
 	}
 
 	@ExceptionHandler(Exception.class)
 	protected ResponseEntity<CommonResponse<ErrorResponse>> handleException(Exception e) {
-		log.warn(">>> Exception: {}", e.getMessage());
+		log.warn("Exception >>> {}", e.getMessage());
 		final ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR);
 		return new ResponseEntity<>(CommonResponse.error(errorResponse), HttpStatus.INTERNAL_SERVER_ERROR);
 	}

--- a/chat-api/src/main/java/com/nameless/social/api/model/ClubModel.java
+++ b/chat-api/src/main/java/com/nameless/social/api/model/ClubModel.java
@@ -12,7 +12,7 @@ import java.util.List;
 @Setter
 @Builder
 public class ClubModel {
-	private Long id;
+	private long id;
 	private String name;
 	private List<UserModel> participants;
 	private LocalDateTime createdAt;

--- a/chat-api/src/main/java/com/nameless/social/api/repository/UserClubRepository.java
+++ b/chat-api/src/main/java/com/nameless/social/api/repository/UserClubRepository.java
@@ -10,9 +10,15 @@ import java.util.List;
 
 @Repository
 public interface UserClubRepository extends JpaRepository<UserClub, Long> {
+	// 존재 여부 확인 (LIMIT 1)
+	boolean existsByIdUserId(long userId);
+
+	// 해당 userId로 모든 UserClub 삭제
+	void deleteByIdUserId(long userId);
+
 	@Query("SELECT uc FROM UserClub uc WHERE uc.user.id = :userId AND uc.club.id IN :clubIds")
-	List<UserClub> findUserClubsInClubIds(@Param("userId") Long userId, @Param("clubIds") List<Long> clubIds);
+	List<UserClub> findByUserClubsInClubIds(@Param("userId") long userId, @Param("clubIds") List<Long> clubIds);
 
 	@Query("DELETE FROM UserClub uc WHERE uc.user.id = :userId AND uc.club.id = :clubId")
-	List<UserClub> deleteByUserIdAndClubId(@Param("userId") Long userId, @Param("clubId") Long clubId);
+	int deleteByUserIdAndClubId(@Param("userId") long userId, @Param("clubId") Long clubId);
 }

--- a/chat-api/src/main/java/com/nameless/social/api/repository/UserGroupRepository.java
+++ b/chat-api/src/main/java/com/nameless/social/api/repository/UserGroupRepository.java
@@ -6,4 +6,9 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserGroupRepository extends JpaRepository<UserGroup, Long> {
+	// 존재 여부 확인 (LIMIT 1)
+	boolean existsByIdUserId(long userId);
+
+	// 해당 userId로 모든 UserGroup 삭제
+	void deleteByIdUserId(long userId);
 }

--- a/chat-api/src/main/resources/db/changelog/250808-delete-not-null.yaml
+++ b/chat-api/src/main/resources/db/changelog/250808-delete-not-null.yaml
@@ -1,0 +1,10 @@
+databaseChangeLog:
+  - changeSet:
+      id: 1
+      author: yeeun
+      context: chat
+      changes:
+        - dropNotNullConstraint:
+            tableName: users
+            columnName: token
+            columnDataType: VARCHAR(255)  # 기존 타입과 정확히 일치시켜야 함

--- a/chat-api/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/chat-api/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -3,3 +3,5 @@ databaseChangeLog:
       file: db/changelog/250731-initial-schema.yaml
   - include:
       file: db/changelog/250808-insert-data.yaml
+  - include:
+      file: db/changelog/250808-delete-not-null.yaml

--- a/chat-api/src/test/java/com/nameless/social/api/service/UserServiceTest.java
+++ b/chat-api/src/test/java/com/nameless/social/api/service/UserServiceTest.java
@@ -6,8 +6,6 @@ import com.nameless.social.api.model.user.UserModel;
 import com.nameless.social.api.repository.UserClubRepository;
 import com.nameless.social.api.repository.UserGroupRepository;
 import com.nameless.social.api.repository.user.UserRepository;
-import com.nameless.social.core.entity.Club;
-import com.nameless.social.core.entity.Group;
 import com.nameless.social.core.entity.User;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -22,8 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class UserServiceTest {
@@ -37,14 +34,10 @@ class UserServiceTest {
 	private UserGroupRepository userGroupRepository;
 
 	private User user;
-	private Group group;
-	private Club club;
 
 	@BeforeEach
 	void setUp() {
 		user = new User("test token", "test", "test@test.com");
-		group = new Group("test Group");
-		club = new Club("test Club");
 	}
 
 	@Test
@@ -83,13 +76,30 @@ class UserServiceTest {
 		// given
 		final String email = "test@test.com";
 		given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+		given(userClubRepository.existsByIdUserId(user.getId())).willReturn(true);
+		given(userGroupRepository.existsByIdUserId(user.getId())).willReturn(true);
 
 		// when
 		userService.deleteUser(email);
 
 		// then
-		verify(userClubRepository, times(1)).deleteByUserId(anyLong());
-		verify(userGroupRepository, times(1)).deleteByUserId(anyLong());
+		verify(userClubRepository, times(1)).deleteByIdUserId(anyLong());
+		verify(userGroupRepository, times(1)).deleteByIdUserId(anyLong());
 		verify(userRepository, times(1)).deleteById(anyLong());
 	}
+
+//	@Test
+//	@DisplayName("user 탈퇴 실패 - user가 가입한 club이 존재하지 않음")
+//	void deleteUserFailTest_notFoundAnyClub() {
+//		// given
+//		final String email = "test@test.com";
+//		given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+//		given(userClubRepository.existsByIdUserId(user.getId())).willReturn(false);
+//
+//		// when
+//		userService.deleteUser(email);
+//
+//		// then
+//		verify(userClubRepository, never()).deleteByIdUserId(anyLong());
+//	}
 }

--- a/chat-api/src/test/java/com/nameless/social/api/service/UserServiceTest.java
+++ b/chat-api/src/test/java/com/nameless/social/api/service/UserServiceTest.java
@@ -3,20 +3,27 @@ package com.nameless.social.api.service;
 import com.nameless.social.api.exception.CustomException;
 import com.nameless.social.api.exception.ErrorCode;
 import com.nameless.social.api.model.user.UserModel;
+import com.nameless.social.api.repository.UserClubRepository;
+import com.nameless.social.api.repository.UserGroupRepository;
 import com.nameless.social.api.repository.user.UserRepository;
+import com.nameless.social.core.entity.Club;
+import com.nameless.social.core.entity.Group;
 import com.nameless.social.core.entity.User;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class UserServiceTest {
@@ -24,6 +31,21 @@ class UserServiceTest {
 	private UserService userService;
 	@Mock
 	private UserRepository userRepository;
+	@Mock
+	private UserClubRepository userClubRepository;
+	@Mock
+	private UserGroupRepository userGroupRepository;
+
+	private User user;
+	private Group group;
+	private Club club;
+
+	@BeforeEach
+	void setUp() {
+		user = new User("test token", "test", "test@test.com");
+		group = new Group("test Group");
+		club = new Club("test Club");
+	}
 
 	@Test
 	@DisplayName("유저 이메일 조회 성공")
@@ -53,5 +75,21 @@ class UserServiceTest {
 			userService.getUserInfo(email);
 		});
 		assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.USER_NOT_FOUND);
+	}
+
+	@Test
+	@DisplayName("user 탈퇴")
+	void deleteUserTest() {
+		// given
+		final String email = "test@test.com";
+		given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+
+		// when
+		userService.deleteUser(email);
+
+		// then
+		verify(userClubRepository, times(1)).deleteByUserId(anyLong());
+		verify(userGroupRepository, times(1)).deleteByUserId(anyLong());
+		verify(userRepository, times(1)).deleteById(anyLong());
 	}
 }

--- a/chat-core/src/main/java/com/nameless/social/core/entity/Club.java
+++ b/chat-core/src/main/java/com/nameless/social/core/entity/Club.java
@@ -14,7 +14,7 @@ import java.util.List;
 public class Club extends BaseTimeEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
+	private long id;
 
 	@Column(nullable = false)
 	private String name;

--- a/chat-core/src/main/java/com/nameless/social/core/entity/Group.java
+++ b/chat-core/src/main/java/com/nameless/social/core/entity/Group.java
@@ -15,7 +15,7 @@ import java.util.List;
 public class Group extends BaseTimeEntity { // Category
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
+	private long id;
 
 	@Column(nullable = false)
 	private String name;

--- a/chat-core/src/main/java/com/nameless/social/core/entity/User.java
+++ b/chat-core/src/main/java/com/nameless/social/core/entity/User.java
@@ -16,7 +16,7 @@ import java.util.List;
 public class User extends BaseTimeEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
+	private long id;
 
 	@Column(unique = true, nullable = false)
 	private String token; // AWS Cognito User-sub

--- a/chat-core/src/main/java/com/nameless/social/core/entity/UserClubId.java
+++ b/chat-core/src/main/java/com/nameless/social/core/entity/UserClubId.java
@@ -15,8 +15,8 @@ import java.util.Objects;
 @NoArgsConstructor
 @Embeddable
 public class UserClubId implements Serializable {
-	private Long userId;
-	private Long clubId;
+	private long userId;
+	private long clubId;
 
 	// equals()와 hashCode() 반드시 override 필요!
 	// @EmbeddedId, @IdClass를 사용하는 경우 키 비교를 정확히 하려면 필수입니다.


### PR DESCRIPTION
- Entity의 id가 Long 타입인 경우, Junit Test에서 anyLong()을 사용했을 때 null로 전달하기 때문에 오류가 발생했습니다. 그래서 Long 타입을 long 타입으로 수정하여 anyLong()을 사용했을 때 0으로 전달하도록 했습니다.
- 사용자 탈퇴 API 추가
- 사용자가 서비스를 탈퇴하면 사용자가 가입한 Group, Club 매핑 데이터도 제거됩니다.
- User Table에서 token 컬럼은 null 허용으로 수정하였습니다.