### PR TITLE
bug/CORS

### DIFF
--- a/chat-websocket/src/main/java/com/nameless/social/websocket/config/WebSocketConfig.java
+++ b/chat-websocket/src/main/java/com/nameless/social/websocket/config/WebSocketConfig.java
@@ -18,7 +18,13 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 	@Override
 	public void registerStompEndpoints(StompEndpointRegistry registry) {
 		registry.addEndpoint("/ws") // 클라이언트에서 WebSocket 연결을 위한 엔드포인트
-				.setAllowedOrigins("*")
+				.setAllowedOrigins(
+						"http://localhost:4200",
+						"https://server.teamnameless.click",
+						"https://stage.teamnameless.click",
+						"https://www.teamnameless.click",
+						"https://teamnameless.click"
+				)
 				.withSockJS();
 	}
 }


### PR DESCRIPTION
- SockJS의 초기 핸드셰이크는 HTTP 요청이므로 OPTIONS 요청을 허용해야 하고, 이 부분이 Spring Security나 ALB에서 차단되면 CORS가 터집니다.